### PR TITLE
Fix : order id shown in order history

### DIFF
--- a/src/pages/orders/[id].astro
+++ b/src/pages/orders/[id].astro
@@ -24,7 +24,7 @@ const { order } = await getOrders(orderId || "");
             size="h5/bold"
             className=" tracking-tight sm:text-3xl"
           >
-            {`Order #${order.id.slice(-6, -1)}`}
+            {`Order #${order.id.slice(-6)}`}
           </Typography>
           <!-- <a
             href="#"


### PR DESCRIPTION
![image](https://github.com/curiosta/curiosta-website/assets/106578262/2b040bc3-e148-4e0c-9f3d-fc70f03f76db)
