### PR TITLE
fix: add custom font weight

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,51 +1,54 @@
-const colors = require('tailwindcss/colors')
+const colors = require("tailwindcss/colors");
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   theme: {
     extend: {
       colors: {
         primary: colors.indigo,
         danger: colors.red,
         secondray: colors.white,
-        success: colors.green
+        success: colors.green,
       },
       textColor: {
         primary: colors.gray,
-        'app-primary': colors.indigo,
+        "app-primary": colors.indigo,
         disabled: colors.gray[400],
-        success: colors.green
+        success: colors.green,
       },
       screens: {
-        xs: '380px'
+        xs: "380px",
       },
       keyframes: {
-        'mini-expand': {
+        "mini-expand": {
           from: {
             opacity: 0,
-            transform: 'scale(0.95)'
+            transform: "scale(0.95)",
           },
           to: {
             opacity: 1,
-            transform: 'scale(1)'
-          }
+            transform: "scale(1)",
+          },
         },
-        'mini-shrink': {
+        "mini-shrink": {
           from: {
             opacity: 1,
-            transform: 'scale(1)'
+            transform: "scale(1)",
           },
           to: {
             opacity: 0,
-            transform: 'scale(0.95)'
-          }
-        }
-      }
+            transform: "scale(0.95)",
+          },
+        },
+      },
+      fontWeight: {
+        medium: "501",
+      },
     },
     animation: {
-      'mini-expand': 'mini-expand 150ms linear forwards',
-      'mini-shrink': 'mini-shrink 150ms linear forwards'
-    }
+      "mini-expand": "mini-expand 150ms linear forwards",
+      "mini-shrink": "mini-shrink 150ms linear forwards",
+    },
   },
-  plugins: [require('@tailwindcss/typography'), require('@tailwindcss/forms')]
-}
+  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/forms")],
+};


### PR DESCRIPTION
In Firefox browser font weight 500 does not works and render text as normal font weight. so, I customized font medium to 501. Now it is working fine in Firefox as well as chromium browser.

### Screenshots
> In Firefox browser 

![image](https://github.com/curiosta/curiosta-website/assets/106578262/8090e0ca-744f-48b5-8105-0e370cb8f578)


..

> In Edge browser 

![image](https://github.com/curiosta/curiosta-website/assets/106578262/6712f03d-3c80-4248-9e98-3ebb9a9e7e34)


close #177 